### PR TITLE
Fix test_order_by_metric_tag_param

### DIFF
--- a/magefiles/dev.go
+++ b/magefiles/dev.go
@@ -12,7 +12,11 @@ import (
 func Dev() error {
 	mg.Deps(Generate)
 
-	return sh.RunV(
+	return sh.RunWithV(
+		map[string]string{
+			"PYTHON_LOGGING_LEVEL":        "DEBUG",
+			"MLFLOW_SQLALCHEMYSTORE_ECHO": "True",
+		},
 		"mlflow-go",
 		"server",
 		"--backend-store-uri",

--- a/magefiles/tests.go
+++ b/magefiles/tests.go
@@ -33,11 +33,12 @@ func (Test) Python() error {
 	if err := sh.RunWithV(map[string]string{
 		"MLFLOW_GO_LIBRARY_PATH": libpath,
 	}, "pytest",
+		"-s",
 		"--confcutdir=.",
-		".mlflow.repo/tests/tracking/test_rest_tracking.py",
-		".mlflow.repo/tests/tracking/test_model_registry.py",
-		".mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py",
-		".mlflow.repo/tests/store/model_registry/test_sqlalchemy_store.py",
+		// ".mlflow.repo/tests/tracking/test_rest_tracking.py",
+		// ".mlflow.repo/tests/tracking/test_model_registry.py",
+		".mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_nojaf",
+		// ".mlflow.repo/tests/store/model_registry/test_sqlalchemy_store.py",
 		"-k",
 		"not [file",
 	); err != nil {


### PR DESCRIPTION
In order to fix the unit test: `.mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_order_by_metric_tag_param`, we need to sort metric values accordinging to the `is_nan` column.

Sample search request:

```
POST http://localhost:5000/api/2.0/mlflow/runs/search
Content-Type: application/json

{
    "experiment_ids":["4"],
    "filter":"",
    "max_results":100,
    "order_by":["metrics.x asc", "metrics.y asc"]
}
```

(values created by

```python
def test_nojaf():
    store = SqlAlchemyStore("postgresql://postgres:postgres@0.0.0.0:5432/postgres")
    experiment_id = store.create_experiment("order_by_metric_2")

    def create_and_log_run(names):
        name = str(names[0]) + "/" + names[1]
        run_id = store.create_run(
            experiment_id,
            user_id="MrDuck",
            start_time=123,
            tags=[entities.RunTag("metric", names[1])],
            run_name=name,
        ).info.run_id
        if names[0] is not None:
            store.log_metric(run_id, entities.Metric("x", float(names[0]), 1, 0))
            store.log_metric(run_id, entities.Metric("y", float(names[1]), 1, 0))
        store.log_param(run_id, entities.Param("metric", names[1]))
        return run_id

    # the expected order in ascending sort is :
    # inf > number > -inf > None > nan
    for names in zip(
        [None, "nan", "inf", "-inf", "-1000", "0", "0", "1000"],
        ["1", "2", "3", "4", "5", "6", "7", "8"],
    ):
        create_and_log_run(names)
```
)

The SQL query python produces:

```sql
-- Python
SELECT DISTINCT runs.run_uuid,
                runs.name,
                runs.source_type,
                runs.source_name,
                runs.entry_point_name,
                runs.user_id,
                runs.status,
                runs.start_time,
                runs.end_time,
                runs.deleted_time,
                runs.source_version,
                runs.lifecycle_stage,
                runs.artifact_uri,
                runs.experiment_id,
                CASE
                    WHEN (anon_1.is_nan = true) THEN %(param_1)s
                    WHEN (anon_1.value IS NULL) THEN %(param_2)s
                    ELSE %(param_3)s END AS clause_1,
                anon_1.value,
                CASE
                    WHEN (anon_2.is_nan = true) THEN %(param_4)s
                    WHEN (anon_2.value IS NULL) THEN %(param_5)s
                    ELSE %(param_6)s END AS clause_2,
                anon_2.value             AS value_1
FROM runs
         LEFT OUTER JOIN (SELECT latest_metrics.key       AS key,
                                 latest_metrics.value     AS value,
                                 latest_metrics.timestamp AS timestamp,
                                 latest_metrics.step      AS step,
                                 latest_metrics.is_nan    AS is_nan,
                                 latest_metrics.run_uuid  AS run_uuid
                          FROM latest_metrics
                          WHERE latest_metrics.key = % (key_1) s) AS anon_1 ON runs.run_uuid = anon_1.run_uuid
         LEFT OUTER JOIN (SELECT latest_metrics.key       AS key,
                                 latest_metrics.value     AS value,
                                 latest_metrics.timestamp AS timestamp,
                                 latest_metrics.step      AS step,
                                 latest_metrics.is_nan    AS is_nan,
                                 latest_metrics.run_uuid  AS run_uuid
                          FROM latest_metrics
                          WHERE latest_metrics.key = % (key_2) s) AS anon_2 ON runs.run_uuid = anon_2.run_uuid
WHERE runs.experiment_id IN (%(experiment_id_1_1) s)
  AND runs.lifecycle_stage IN (%(lifecycle_stage_1_1) s)
ORDER BY clause_1, anon_1.value, clause_2, anon_2.value, runs.start_time DESC, runs.run_uuid
LIMIT %(param_7)s OFFSET %(param_8)s
```

versus the Go query

```sql
-- Go
SELECT runs.run_uuid,
       runs.name,
       runs.status,
       runs.start_time,
       runs.lifecycle_stage,
       runs.experiment_id,
       order_0.value,
       order_1.value,
       order_0.is_nan,
       order_1.is_nan
FROM runs
         LEFT OUTER JOIN (SELECT run_uuid, value, is_nan FROM latest_metrics WHERE key = 'x') AS order_0
                         ON runs.run_uuid = order_0.run_uuid
         LEFT OUTER JOIN (SELECT run_uuid, value, is_nan FROM latest_metrics WHERE key = 'y') AS order_1
                         ON runs.run_uuid = order_1.run_uuid
WHERE runs.experiment_id IN ('4')
  AND runs.lifecycle_stage IN ('active', 'deleted')
ORDER BY order_0.value, order_1.value, runs.start_time DESC, runs.run_uuid
LIMIT 100
```

We are missing `DISTINCT` and the `                CASE
                    WHEN (anon_1.is_nan = true) THEN %(param_1)s
                    WHEN (anon_1.value IS NULL) THEN %(param_2)s
                    ELSE %(param_3)s END AS clause_1,` part.

I'm not quite sure how to deal with this and would like to pair on this.