### PR TITLE
Use correct validation error for max length

### DIFF
--- a/.mlflow.ref
+++ b/.mlflow.ref
@@ -1,1 +1,1 @@
-https://github.com/mlflow/mlflow.git#master
+https://github.com/nojaf/mlflow.git#exceeds-maximum-length

--- a/.mlflow.ref
+++ b/.mlflow.ref
@@ -1,1 +1,1 @@
-https://github.com/nojaf/mlflow.git#exceeds-maximum-length
+https://github.com/mlflow/mlflow.git#master

--- a/README.md
+++ b/README.md
@@ -280,16 +280,15 @@ The following Python tests are currently failing:
 ```
 ======================================================================================================================== short test summary info ========================================================================================================================
 FAILED .mlflow.repo/tests/tracking/test_rest_tracking.py::test_log_metrics_params_tags[sqlalchemy] - mlflow.exceptions.RestException: INVALID_PARAMETER_VALUE: Invalid value "NaN" for parameter 'value' supplied
-FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_create_experiments - Failed: DID NOT RAISE <class 'mlflow.exceptions.MlflowException'>
-FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_metric_concurrent_logging_succeeds - mlflow.exceptions.MlflowException: error creating metrics in batch for run_uuid "75fc09c87d7a4a3dadd6891cc4fd7f37"
+FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_metric_concurrent_logging_succeeds - mlflow.exceptions.MlflowException: error creating metrics in batch for run_uuid "1938bf6e61744393946e7dedf984123e"
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_order_by_metric_tag_param - AssertionError: assert ['None/1', '-...', '0/7', ...] == ['-inf/4', '-... 'inf/3', ...]
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_order_by_attributes - AssertionError: assert ['-123', 'Non... '456', '789'] == ['-123', '123...'789', 'None']
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_batch_null_metrics - TypeError: must be real number, not NoneType
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_inputs_with_large_inputs_limit_check - AssertionError: assert {'digest': 'd...ema': '', ...} == {'digest': 'd...a': None, ...}
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db - mlflow.exceptions.MlflowException: failed to create experiment
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_create_experiment_appends_to_artifact_local_path_file_uri_correctly[#path/to/local/folder?-{cwd}/#path/to/local/folder?/{e}] - AssertionError: assert '/workspaces/...local/folder?' == '/workspaces/...cal/folder?/1'
-FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_create_run_appends_to_artifact_local_path_file_uri_correctly[#path/to/local/folder?-{cwd}/#path/to/local/folder?/{e}/{r}/artifacts] - AssertionError: assert '/workspaces/...local/folder?' == '/workspaces/...ac7/artifacts'
-========================================================================================== 10 failed, 349 passed, 9 skipped, 128 deselected, 10 warnings in 230.14s (0:03:50) ===========================================================================================
+FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_create_run_appends_to_artifact_local_path_file_uri_correctly[#path/to/local/folder?-{cwd}/#path/to/local/folder?/{e}/{r}/artifacts] - AssertionError: assert '/workspaces/...local/folder?' == '/workspaces/...073/artifacts'
+=========================================================================================== 9 failed, 350 passed, 9 skipped, 128 deselected, 10 warnings in 226.60s (0:03:46) ===========================================================================================
 ```
 
 ## Debug Failing Tests

--- a/magefiles/generate/validations.go
+++ b/magefiles/generate/validations.go
@@ -2,7 +2,7 @@ package generate
 
 var validations = map[string]string{
 	"GetExperiment_ExperimentId":         "required,stringAsPositiveInteger",
-	"CreateExperiment_Name":              "required",
+	"CreateExperiment_Name":              "required,max=500",
 	"CreateExperiment_ArtifactLocation":  "omitempty,uriWithoutFragmentsOrParamsOrDotDotInQuery",
 	"SearchRuns_RunViewType":             "omitempty",
 	"SearchRuns_MaxResults":              "gt=0,max=50000",

--- a/pkg/protos/service.pb.go
+++ b/pkg/protos/service.pb.go
@@ -1191,7 +1191,7 @@ type CreateExperiment struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Experiment name.
-	Name *string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty" query:"name" validate:"required"`
+	Name *string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty" query:"name" validate:"required,max=500"`
 	// Location where all artifacts for the experiment are stored.
 	// If not provided, the remote server will select an appropriate default.
 	ArtifactLocation *string `protobuf:"bytes,2,opt,name=artifact_location,json=artifactLocation" json:"artifact_location,omitempty" query:"artifact_location" validate:"omitempty,uriWithoutFragmentsOrParamsOrDotDotInQuery"`

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -271,6 +271,11 @@ func NewErrorFromValidationError(err error) *contract.Error {
 					validationErrors,
 					"Duplicate parameter keys have been submitted",
 				)
+			case "max":
+				validationErrors = append(
+					validationErrors,
+					fmt.Sprintf("'%s' exceeds the maximum length of %s characters", field, err.Param()),
+				)
 			default:
 				validationErrors = append(
 					validationErrors,

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -228,12 +228,43 @@ func constructValidationError(field string, value any, suffix string) string {
 	return fmt.Sprintf("Invalid value %s for parameter '%s' supplied%s", formattedValue, field, suffix)
 }
 
+func mkTruncateValidationError(field string, value interface{}, err validator.FieldError) string {
+	strValue, ok := value.(string)
+	if ok {
+		expected := len(strValue)
+
+		if expected > MaxValidationInputLength {
+			strValue = strValue[:MaxValidationInputLength] + "..."
+		}
+
+		return constructValidationError(
+			field,
+			strValue,
+			fmt.Sprintf(": length %d exceeded length limit of %s", expected, err.Param()),
+		)
+	}
+
+	return constructValidationError(field, value, "")
+}
+
+func mkMaxValidationError(field string, value interface{}, err validator.FieldError) string {
+	if _, ok := value.(string); ok {
+		return fmt.Sprintf(
+			"'%s' exceeds the maximum length of %s characters",
+			field,
+			err.Param(),
+		)
+	}
+
+	return constructValidationError(field, value, "")
+}
+
 func NewErrorFromValidationError(err error) *contract.Error {
-	var ve validator.ValidationErrors
-	if errors.As(err, &ve) {
+	var validatorValidationErrors validator.ValidationErrors
+	if errors.As(err, &validatorValidationErrors) {
 		validationErrors := make([]string, 0)
 
-		for _, err := range ve {
+		for _, err := range validatorValidationErrors {
 			field := getErrorPath(err)
 			tag := err.Tag()
 			value := dereference(err.Value())
@@ -245,37 +276,14 @@ func NewErrorFromValidationError(err error) *contract.Error {
 					fmt.Sprintf("Missing value for required parameter '%s'", field),
 				)
 			case "truncate":
-				strValue, ok := value.(string)
-				if ok {
-					expected := len(strValue)
-
-					if expected > MaxValidationInputLength {
-						strValue = strValue[:MaxValidationInputLength] + "..."
-					}
-
-					validationErrors = append(
-						validationErrors,
-						constructValidationError(
-							field,
-							strValue,
-							fmt.Sprintf(": length %d exceeded length limit of %s", expected, err.Param())),
-					)
-				} else {
-					validationErrors = append(
-						validationErrors,
-						constructValidationError(field, value, ""),
-					)
-				}
+				validationErrors = append(validationErrors, mkTruncateValidationError(field, value, err))
 			case "uniqueParams":
 				validationErrors = append(
 					validationErrors,
 					"Duplicate parameter keys have been submitted",
 				)
 			case "max":
-				validationErrors = append(
-					validationErrors,
-					fmt.Sprintf("'%s' exceeds the maximum length of %s characters", field, err.Param()),
-				)
+				validationErrors = append(validationErrors, mkMaxValidationError(field, value, err))
 			default:
 				validationErrors = append(
 					validationErrors,


### PR DESCRIPTION
Makes `tests/store/tracking/test_sqlalchemy_store.py::test_create_experiments` pass.
Needs https://github.com/mlflow/mlflow/pull/13128 though.