### PR TITLE
Return None for empty next_page_token

### DIFF
--- a/mlflow_go/store/tracking.py
+++ b/mlflow_go/store/tracking.py
@@ -144,7 +144,7 @@ class _TrackingStore:
         )
         response = self.service.call_endpoint(get_lib().TrackingServiceSearchRuns, request)
         runs = [Run.from_proto(proto_run) for proto_run in response.runs]
-        return runs, response.next_page_token
+        return runs, (response.next_page_token or None)
 
     def log_batch(self, run_id, metrics, params, tags):
         request = LogBatch(


### PR DESCRIPTION
The sqlalchemystore turns `None` for an empty token, see https://github.com/mlflow/mlflow/blob/650b08af28e8acb9c199bb28ad1558f00ceda35e/mlflow/store/tracking/sqlalchemy_store.py#L1305

Updating our extension to do the same, fixes `test_search_runs_pagination`