### PR TITLE
Ignore test_log_batch_null_metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,9 @@ Sometimes `golangci-lint` can complain about unrelated files, run `golangci-lint
 The following Python tests are currently failing:
 
 ```
-======================================================================================== short test summary info ========================================================================================
-FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_batch_null_metrics - TypeError: must be real number, not NoneType
+===================================================================================================================== short test summary info ======================================================================================================================
 FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_log_inputs_with_large_inputs_limit_check - AssertionError: assert {'digest': 'd...ema': '', ...} == {'digest': 'd...a': None, ...}
-FAILED .mlflow.repo/tests/store/tracking/test_sqlalchemy_store.py::test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db - mlflow.exceptions.MlflowException: failed to create experiment
-=========================================================== 3 failed, 356 passed, 9 skipped, 128 deselected, 10 warnings in 429.04s (0:07:09) ===========================================================
+======================================================================================== 1 failed, 358 passed, 9 skipped, 128 deselected, 10 warnings in 227.64s (0:03:47) =========================================================================================
 ```
 
 ## Debug Failing Tests

--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,13 @@ def pytest_configure(config):
             "tests.store.tracking.test_sqlalchemy_store.test_log_batch_params_max_length_value",
             "tests/override_test_sqlalchemy_store.py",
         ),
+        # This tests calls the store using invalid metric entity that cannot be converted
+        # to its proto counterpart.
+        # Example: entities.Metric("invalid_metric", None, (int(time.time() * 1000)), 0).to_proto()
+        (
+            "tests.store.tracking.test_sqlalchemy_store.test_log_batch_null_metrics",
+            "tests/override_test_sqlalchemy_store.py",
+        ),
     ):
         func_name = func_to_patch.rsplit(".", 1)[1]
         new_func_file = (

--- a/conftest.py
+++ b/conftest.py
@@ -49,7 +49,7 @@ def pytest_configure(config):
         # We do not support applying the SQL schema to sqlite like Python does.
         # So we do not support sqlite:////:memory: database.
         (
-            "tests.store.tracking.test_sqlalchemy_store.test_log_batch_null_metrics.test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db",
+            "tests.store.tracking.test_sqlalchemy_store.test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db",
             "tests/override_test_sqlalchemy_store.py",
         ),
     ):

--- a/conftest.py
+++ b/conftest.py
@@ -46,6 +46,12 @@ def pytest_configure(config):
             "tests.store.tracking.test_sqlalchemy_store.test_log_batch_null_metrics",
             "tests/override_test_sqlalchemy_store.py",
         ),
+        # We do not support applying the SQL schema to sqlite like Python does.
+        # So we do not support sqlite:////:memory: database.
+        (
+            "tests.store.tracking.test_sqlalchemy_store.test_log_batch_null_metrics.test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db",
+            "tests/override_test_sqlalchemy_store.py",
+        ),
     ):
         func_name = func_to_patch.rsplit(".", 1)[1]
         new_func_file = (

--- a/tests/override_test_sqlalchemy_store.py
+++ b/tests/override_test_sqlalchemy_store.py
@@ -7,3 +7,7 @@ def test_log_batch_internal_error(store: SqlAlchemyStore):
 
 def test_log_batch_params_max_length_value(store: SqlAlchemyStore, monkeypatch):
     ()
+
+
+def test_log_batch_null_metrics(store: SqlAlchemyStore):
+    ()

--- a/tests/override_test_sqlalchemy_store.py
+++ b/tests/override_test_sqlalchemy_store.py
@@ -11,3 +11,7 @@ def test_log_batch_params_max_length_value(store: SqlAlchemyStore, monkeypatch):
 
 def test_log_batch_null_metrics(store: SqlAlchemyStore):
     ()
+
+
+def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db(monkeypatch):
+    ()


### PR DESCRIPTION
We should skip `test_log_batch_null_metrics` as there is no way to invoke the store method with the invalid proto counterpart.

Also ignore `test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db`